### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/renovate-config-validation.yml
+++ b/.github/workflows/renovate-config-validation.yml
@@ -1,5 +1,8 @@
 name: Renovate config validation
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ThorstenSauter/renovate-config/security/code-scanning/1](https://github.com/ThorstenSauter/renovate-config/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only validates Renovate configurations, it likely only needs read access to the repository contents. We will set `contents: read` as the minimal required permission. This change ensures that the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
