### PR TITLE
chore(config): modernize renovate presets and add stability window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 .vs/
 .vscode/
+
+.claude/

--- a/default.json
+++ b/default.json
@@ -1,16 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":disableRateLimiting",
     "schedule:daily",
-    ":semanticCommits"
+    ":semanticCommits",
+    ":enableVulnerabilityAlerts"
   ],
-  "assigneesFromCodeOwners": true,
+  "configMigration": true,
+  "reviewersFromCodeOwners": true,
   "labels": [
     "dependencies"
   ],
   "packageRules": [
+    {
+      "matchPackageNames": ["*"],
+      "stabilityDays": 3
+    },
     {
       "matchManagers": [
         "dockerfile",


### PR DESCRIPTION
## Summary

- Replace deprecated `config:base` with `config:recommended`
- Add `:enableVulnerabilityAlerts` to bypass schedule for security fixes
- Add `configMigration: true` to auto-migrate deprecated config keys
- Switch `assigneesFromCodeOwners` → `reviewersFromCodeOwners`
- Add `stabilityDays: 3` on all packages as a supply chain defence
- Update `.gitignore` to exclude `.claude/`

## Test plan

- [ ] Verify Renovate picks up the new config without errors
- [ ] Confirm vulnerability alerts are raised independently of the daily schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)