### PR TITLE
feat(config): exempt trusted publishers from 3-day stability window

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,6 +18,28 @@
       "stabilityDays": 3
     },
     {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": [
+        "Aspire.**",
+        "Azure.**",
+        "Microsoft.**"
+      ],
+      "stabilityDays": 0
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@azure/**",
+        "next",
+        "@next/**",
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "stabilityDays": 0
+    },
+    {
       "matchManagers": [
         "dockerfile",
         "docker-compose"


### PR DESCRIPTION
## Summary

- Adds a NuGet override rule exempting `Aspire.**`, `Azure.**`, and `Microsoft.**` packages from the 3-day stability window
- Adds an npm override rule exempting `@azure/**`, `next`, `@next/**`, `react`, `react-dom`, `@types/react`, and `@types/react-dom`
- All other packages continue to respect the existing `stabilityDays: 3` catch-all rule

## How it works

Renovate evaluates `packageRules` top-to-bottom with later rules overriding earlier ones. The two new rules are placed immediately after the catch-all stability rule and set `stabilityDays: 0` for the trusted publishers, so their updates are picked up as soon as they are released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)